### PR TITLE
More precise usage of AuthenticationError

### DIFF
--- a/stormshield/sns/sslclient/__init__.py
+++ b/stormshield/sns/sslclient/__init__.py
@@ -398,8 +398,8 @@ class SSLClient:
         try:
             nws_node = ElementTree.fromstring(request.content)
             msg = nws_node.attrib['msg']
-        except:
-            raise AuthenticationError("Can't decode authentication result")
+        except (ElementTree.ParseError, KeyError):
+            raise ServerError("Can't decode authentication result")
 
         if  msg != self.AUTH_SUCCESS:
             raise AuthenticationError("Authentication failed")
@@ -457,7 +457,9 @@ class SSLClient:
         if code == self.SSL_SERVERD_OK:
             return
 
-        if code in self.SSL_SERVERD_MSG:
+        if code == self.SSL_SERVERD_AUTH_ERROR:
+            raise AuthenticationError(self.SSL_SERVERD_MSG[code])
+        elif code in self.SSL_SERVERD_MSG:
             raise ServerError(self.SSL_SERVERD_MSG[code])
         else:
             raise ServerError("Unknown error")


### PR DESCRIPTION
Hello,

I see two problems with the `AuthenticationError` usage:
- [During logging](https://github.com/stormshield/python-SNS-API/blob/7e2f8ce971ceb76fbd7143275eb9a364d6f6ac78/stormshield/sns/sslclient/__init__.py#L398-L405), an `AuthenticationError` can be raised both for an authentication failure and a parsing error of the response from the server. 
- The error conversion [here](https://github.com/stormshield/python-SNS-API/blob/7e2f8ce971ceb76fbd7143275eb9a364d6f6ac78/stormshield/sns/sslclient/__init__.py#L454-L463) can raise a ServerError on authentication error.

This should resolve both issues.