### PR TITLE
Allow parenthesis in token

### DIFF
--- a/stormshield/sns/configparser.py
+++ b/stormshield/sns/configparser.py
@@ -94,7 +94,7 @@ class ConfigParser:
                     line = line.encode('utf-8')
                 # parse token=value token2=value2
                 lexer = shlex(line, posix=True)
-                lexer.wordchars += "=.-*:,/@'"
+                lexer.wordchars += "=.-*:,/@'()"
                 lexer.quotes = '"'
                 parsed = {}
                 for word in lexer:


### PR DESCRIPTION
Allowing parenthesis in tokens provide the ability to cope with objects that have some in their names