### PR TITLE
support for SNS v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ client.disconnect()
 
 ```
 
+* **Note:** SNS version >= 5.0 uses a custom CA and certificate by default. To connect to it, the "SNS-WebServer-default-authority" CA must be retrieved from the appliance (e.g. downloading the CA certificate using the webgui), then added to your cabundle.pem.
+
+(alternatively, CA verification can be bypassed using `sslverifypeer=False` argument to SSLClient() )
+
 ### Command results
 
 Command results are available in text, xml or python structure formats:
@@ -104,6 +108,10 @@ Concerning the SSL validation:
 * To connect to a known appliance with the default certificate use `--host <serial> --ip <ip address>` to validate the peer certificate.
 * If a custom CA and certificate is installed, use `--host myfirewall.tld --cabundle <ca.pem>`. CA bundle should contain at least the root CA.
 * For client certificate authentication, the expected format is a PEM file with the certificate and the unencrypted key concatenated.
+
+* **Note:** SNS version >= 5.0 uses a custom CA and certificate by default. To connect to it, the "SNS-WebServer-default-authority" CA must be retrieved from the appliance (e.g. downloading the CA certificate using the webgui), then `--cabundle <ca.pem>` must be used.
+
+(alternatively, CA verification can be bypassed with `--no-sslverifypeer` option)
 
 ## Proxy
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -7,6 +7,7 @@ from stormshield.sns.sslclient import SSLClient
 APPLIANCE = os.getenv('APPLIANCE', "")
 SERIAL = os.getenv('SERIAL', "")
 PASSWORD = os.getenv('PASSWORD', "")
+SSLVERIFYPEER = os.getenv('SSLVERIFYPEER', "1") == "1";
 
 @unittest.skipIf(APPLIANCE=="", "APPLIANCE env var must be set to the ip/hostname of a running SNS appliance")
 @unittest.skipIf(SERIAL=="", "SERIAL env var must be set to the firewall serial number")
@@ -18,7 +19,7 @@ class TestAuth(unittest.TestCase):
         """ Test sslverifyhost option """
 
         try:
-            client = SSLClient(host=SERIAL, ip=APPLIANCE, user='admin', password=PASSWORD, sslverifyhost=True)
+            client = SSLClient(host=SERIAL, ip=APPLIANCE, user='admin', password=PASSWORD, sslverifyhost=True, sslverifypeer=SSLVERIFYPEER)
             self.assertTrue(1==1, "SSLClient connects with sslverifyhost=True")
         except:
             self.fail("SSLClient did not connect")

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -13,6 +13,7 @@ from stormshield.sns.sslclient import SSLClient
 
 APPLIANCE = os.getenv('APPLIANCE', "")
 PASSWORD = os.getenv('PASSWORD', "")
+SSLVERIFYPEER = os.getenv('SSLVERIFYPEER', "1") == "1";
 
 @unittest.skipIf(APPLIANCE=="", "APPLIANCE env var must be set to the ip/hostname of a running SNS appliance")
 @unittest.skipIf(PASSWORD=="", "PASSWORD env var must be set to the firewall password")
@@ -20,7 +21,7 @@ class TestFormatIni(unittest.TestCase):
     """ Test file upload & download """
 
     def setUp(self):
-        self.client = SSLClient(host=APPLIANCE, user='admin', password=PASSWORD, sslverifyhost=False)
+        self.client = SSLClient(host=APPLIANCE, user='admin', password=PASSWORD, sslverifyhost=False, sslverifypeer=SSLVERIFYPEER)
 
         self.tmpdir = tempfile.mkdtemp()
         self.upload = os.path.join(self.tmpdir, 'upload')

--- a/tests/test_format_ini.py
+++ b/tests/test_format_ini.py
@@ -9,6 +9,7 @@ from stormshield.sns.sslclient import SSLClient
 
 APPLIANCE = os.getenv('APPLIANCE', "")
 PASSWORD = os.getenv('PASSWORD', "")
+SSLVERIFYPEER = os.getenv('SSLVERIFYPEER', "1") == "1";
 
 @unittest.skipIf(APPLIANCE=="", "APPLIANCE env var must be set to the ip/hostname of a running SNS appliance")
 @unittest.skipIf(PASSWORD=="", "PASSWORD env var must be set to the firewall password")
@@ -16,7 +17,7 @@ class TestFormatIni(unittest.TestCase):
     """ Test INI format """
 
     def setUp(self):
-        self.client = SSLClient(host=APPLIANCE, user='admin', password=PASSWORD, sslverifyhost=False)
+        self.client = SSLClient(host=APPLIANCE, user='admin', password=PASSWORD, sslverifyhost=False, sslverifypeer=SSLVERIFYPEER)
 
         self.maxDiff = 5000
 

--- a/tests/test_utf8.py
+++ b/tests/test_utf8.py
@@ -10,6 +10,7 @@ from stormshield.sns.sslclient import SSLClient
 
 APPLIANCE = os.getenv('APPLIANCE', "")
 PASSWORD = os.getenv('PASSWORD', "")
+SSLVERIFYPEER = os.getenv('SSLVERIFYPEER', "1") == "1";
 
 @unittest.skipIf(APPLIANCE=="", "APPLIANCE env var must be set to the ip/hostname of a running SNS appliance")
 @unittest.skipIf(PASSWORD=="", "PASSWORD env var must be set to the firewall password")
@@ -17,7 +18,7 @@ class TestUtf8(unittest.TestCase):
     """ Test INI format """
 
     def setUp(self):
-        self.client = SSLClient(host=APPLIANCE, user='admin', password=PASSWORD, sslverifyhost=False)
+        self.client = SSLClient(host=APPLIANCE, user='admin', password=PASSWORD, sslverifyhost=False, sslverifypeer=SSLVERIFYPEER)
         self.client.send_command('CONFIG OBJECT HOST NEW type=host name=hostutf8 ip=1.2.3.4 comment="comment with utf8 characters éè\u2713"')
 
         self.maxDiff = 5000


### PR DESCRIPTION
- README has been updated to explain SNS v5 new default behavior
- tests using the default certificate can now be run without ssl peer verification if the SSLVERIFYPEER environment variable is set to 0